### PR TITLE
Added the number of online players as a Gauge to display.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022 LOENS2
+Copyright (c) 2023 noesterle
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ Post any stacktraces as an Issue.
 With special thanks to @grimsi for helping me with docker.
 
 &copy; LOENS2 2022
+&copy; noesterle 2023

--- a/modified_sources/bloom.py
+++ b/modified_sources/bloom.py
@@ -1,0 +1,21 @@
+from prometheus_client import Gauge
+
+class Bloom:
+
+    def __init__(self):
+        self.online_players = None
+
+    def add_srv_keys(self, srv):
+        srv['online_players'] = []
+
+    def add_gauge(self, label_names):
+        self.online_players = Gauge("pterodactyl_server_online_players", "Number of players online for the server", label_names)
+
+    def serve_metrics(self, srv_label, id_label, metrics, server_index):
+        self.online_players.labels(srv_label, id_label).set(metrics["online_players"])
+
+    def get_metrics(self,srv,metrics):
+        if "online_players" in metrics:
+            srv["online_players"] = metrics["online_players"]
+        else:
+            srv["online_players"] = -1.0

--- a/pterodactyl_exporter/http_client.py
+++ b/pterodactyl_exporter/http_client.py
@@ -36,6 +36,7 @@ def get_server(list_type="owner"):
         "io": [],
         "max_cpu": [],
         "last_backup_time": [],
+        "online_players": [],
     }
     client.request("GET", "/api/client/?type={}".format(list_type), "", headers)
     servers = json.loads(client.getresponse().read())

--- a/pterodactyl_exporter/http_client.py
+++ b/pterodactyl_exporter/http_client.py
@@ -68,6 +68,11 @@ def get_metrics():
         srv["rx"].append(metrics["network_rx_bytes"]/1000000)
         srv["tx"].append(metrics["network_tx_bytes"]/1000000)
         srv["uptime"].append(metrics["uptime"])
+        if "online_players" in metrics:
+            srv["online_players"] = metrics["online_players"]
+        else:
+            srv["online_players"] = -1.0
+
 
         get_last_backup_time(x, 1)
 

--- a/pterodactyl_exporter/http_server.py
+++ b/pterodactyl_exporter/http_server.py
@@ -15,14 +15,15 @@ max_disk = Gauge("pterodactyl_server_max_disk_megabytes", "Maximum disk space al
 io = Gauge("pterodactyl_server_io", "IO weight of server", label_names)
 max_cpu = Gauge("pterodactyl_server_max_cpu_absolute", "Maximum cpu load allowed to server", label_names)
 last_backup_time = Gauge("pterodactyl_server_most_recent_backup_time", "Timestamp of the most recent backup", label_names)
-online_players = Gauge("pterodactyl_server_online_players", "Number of players online for the server", label_names)
 
 
-def init_metrics():
+def init_metrics(mod_server=None):
     start_http_server(9531)
+    if mod_server is not None:
+        mod_server.add_gauge(label_names)
 
 
-def serve_metrics(metrics):
+def serve_metrics(metrics, mod_server=None):
     for x in range(len(metrics["id"])):
         srv_label = metrics['name'][x]
         id_label = metrics['id'][x]
@@ -38,4 +39,6 @@ def serve_metrics(metrics):
         io.labels(srv_label, id_label).set(metrics["io"][x])
         max_cpu.labels(srv_label, id_label).set(metrics["max_cpu"][x])
         last_backup_time.labels(srv_label, id_label).set(metrics["last_backup_time"][x])
-        online_players.labels(srv_label, id_label).set(metrics["online_players"])
+
+        if mod_server is not None:
+            mod_server.serve_metrics(srv_label, id_label, metrics, x)

--- a/pterodactyl_exporter/http_server.py
+++ b/pterodactyl_exporter/http_server.py
@@ -15,6 +15,7 @@ max_disk = Gauge("pterodactyl_server_max_disk_megabytes", "Maximum disk space al
 io = Gauge("pterodactyl_server_io", "IO weight of server", label_names)
 max_cpu = Gauge("pterodactyl_server_max_cpu_absolute", "Maximum cpu load allowed to server", label_names)
 last_backup_time = Gauge("pterodactyl_server_most_recent_backup_time", "Timestamp of the most recent backup", label_names)
+online_players = Gauge("pterodactyl_server_online_players", "Number of players online for the server", label_names)
 
 
 def init_metrics():
@@ -37,3 +38,4 @@ def serve_metrics(metrics):
         io.labels(srv_label, id_label).set(metrics["io"][x])
         max_cpu.labels(srv_label, id_label).set(metrics["max_cpu"][x])
         last_backup_time.labels(srv_label, id_label).set(metrics["last_backup_time"][x])
+        online_players.labels(srv_label, id_label).set(metrics["online_players"])

--- a/pterodactyl_exporter/pterodactyl_exporter.py
+++ b/pterodactyl_exporter/pterodactyl_exporter.py
@@ -21,19 +21,29 @@ def main(args=None):
         args = sys.argv[1:]
     config_file = parse_args()
     config = config_load.get_config(config_file)
-    http_client.client_init(config)
-    http_server.init_metrics()
+    mod_server = get_modified_server(config['host'])
+    http_client.client_init(config, mod_server)
+    http_server.init_metrics(mod_server)
 
     while True:
         try:
             http_client.get_server(config["server_list_type"])
             metrics = http_client.get_metrics()
-            http_server.serve_metrics(metrics)
+            http_server.serve_metrics(metrics, mod_server)
             time.sleep(10)
         except http.client.RemoteDisconnected:
             print("API not responding!")
             time.sleep(10)
             continue
+
+
+def get_modified_server(host):
+    modified_server = None
+    if host == 'mc.bloom.host':
+        from modified_sources.bloom import Bloom as modified_server
+        modified_server = modified_server()
+    
+    return modified_server
 
 
 if __name__ == '__main__':

--- a/pterodactyl_exporter/pterodactyl_exporter.py
+++ b/pterodactyl_exporter/pterodactyl_exporter.py
@@ -42,7 +42,8 @@ def get_modified_server(host):
     if host == 'mc.bloom.host':
         from modified_sources.bloom import Bloom as modified_server
         modified_server = modified_server()
-    
+    # elif host == 'example.com':
+    #     from modified_sources.example import Example as modified_server
     return modified_server
 
 


### PR DESCRIPTION
Added a Gauge for Online Players to be able to track that metric in Prometheus.

The metric will reflect that if the endpoint supports the `online_players` field in the `resources` object of the servers resources endpoint. If there is no field for `online_players` in the `resources` object, the metric will be set to `-1.0`.